### PR TITLE
Implement "aliases" as second argument, as <optional> replacement for package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 _[`better-module-alias`](https://www.npmjs.com/package/better-module-alias) is an improved version of the fantastic [`module-alias`](https://github.com/ilearnio/module-alias) package._
 
 # Better Module Alias
+
 Fix the issue of having to do relative paths like:
+
 ```
 require('../../../../some/deep/module')
 ```
 
 Instead, make your code look like:
+
 ```
 require('$utils/some/deep/module')
 ```
@@ -14,6 +17,7 @@ require('$utils/some/deep/module')
 ## How do I use it?
 
 ### package.json
+
 _This package uses the same `package.json` formatting as [`module-alias`](https://github.com/ilearnio/module-alias)._
 
 In your `package.json`, add a `_moduleAliases` object formatted like this:
@@ -22,65 +26,69 @@ In your `package.json`, add a `_moduleAliases` object formatted like this:
 {
   "_moduleAliases": {
     "$tests": "./tests",
-    "$utils": "./utils",
-  },
+    "$utils": "./utils"
+  }
 }
 ```
-
 
 - _**NOTE:** Prefixing with `$` is considered a best-practice so it doesn't interfere with `@`-scoped npm packages._
 - _**NOTE:** We prefix a `$` so it's obvious which imports are from npm packages and which come from `better-module-alias`._
 
 ### Node.js
+
 _**NOTE:** `better-module-alias` has to be imported before any `$` imports in your root code file, or it won't work._
 
 If you want to use `better-module-alias` in Node.js, you'll need to import this package at the top of the file that gets run in your `node` command such as `./index.js`.
 
 ```js
-require('better-module-alias')(__dirname)
+require("better-module-alias")(__dirname);
 
 // or
 
-import betterModuleAlias from 'better-module-alias'
-betterModuleAlias(__dirname)
+import betterModuleAlias from "better-module-alias";
+betterModuleAlias(__dirname);
 ```
 
 When you want to require an aliased file, do it like so:
 
 ```js
-const someModule = require('$utils/someModule')
+const someModule = require("$utils/someModule");
 
 // or
 
-import someModule from '$utils/someModule'
+import someModule from "$utils/someModule";
 ```
 
-An *alternative* way is to call the betterModuleAlias function, and pass the aliases as the second argument.
+An _alternative_ way is to call the betterModuleAlias function, and pass the aliases as the second argument.
+
 ```js
-require('better-module-alias')(__dirname, {
-  $tests: './tests',
-  $utils: './utils',
-})
-```
+// Method 1 (using package.json _moduleAliases)
+import betterModuleAlias from "better-module-alias";
+betterModuleAlias(__dirname);
 
-import betterModuleAlias from 'better-module-alias'
-betterModuleAlias(__dirname)
+// Method 2 (using the second argument as aliases)
+require("better-module-alias")(__dirname, {
+  $tests: "./tests",
+  $utils: "./utils",
+});
 ```
 
 #### Examples
 
 ##### Will work:
+
 ```js
 // index.js
-require('better-module-alias')(__dirname)
-const someModule = require('$utils/someModule')
+require("better-module-alias")(__dirname);
+const someModule = require("$utils/someModule");
 ```
 
 ##### Won't work:
+
 ```js
 // index.js
-const someModule = require('$utils/someModule')
-require('better-module-alias')(__dirname)
+const someModule = require("$utils/someModule");
+require("better-module-alias")(__dirname);
 ```
 
 #### Issues with `fs`
@@ -88,30 +96,27 @@ require('better-module-alias')(__dirname)
 Libraries like `fs` won't work with `better-module-alias` because it's overriding the `require` functionality of CommonJS, not file lookups in other libraries. The way to get around that is by using `require.resolve`.
 
 Where you might have done:
+
 ```js
-fs.readFile(
-  '../../../../some/deep/module',
-  callback,
-)
+fs.readFile("../../../../some/deep/module", callback);
 ```
 
 You can use `require.resolve` to do this instead:
+
 ```js
-fs.readFile(
-  require.resolve('$utils/some/deep/module'),
-  callback,
-)
+fs.readFile(require.resolve("$utils/some/deep/module"), callback);
 ```
 
 That'll allow you to get the same functionality without having to have 2 ways of writing the same code.
 
 ### Webpack
+
 Webpack has a built in support for aliases and custom modules directories.
 
 Add this code to your Webpack config to get it working with `better-module-alias`:
 
 ```js
-const packageJson = require('./package.json')
+const packageJson = require("./package.json");
 
 const webpackConfig = {
   // ...
@@ -121,7 +126,7 @@ const webpackConfig = {
     },
   },
   // ...
-}
+};
 ```
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ In your `package.json`, add a `_moduleAliases` object formatted like this:
 }
 ```
 
+
 - _**NOTE:** Prefixing with `$` is considered a best-practice so it doesn't interfere with `@`-scoped npm packages._
 - _**NOTE:** We prefix a `$` so it's obvious which imports are from npm packages and which come from `better-module-alias`._
 
@@ -52,6 +53,18 @@ const someModule = require('$utils/someModule')
 // or
 
 import someModule from '$utils/someModule'
+```
+
+An *alternative* way is to call the betterModuleAlias function, pass the aliases as the second argument.
+```js
+require('better-module-alias')(__dirname, {
+  $tests: './tests',
+  $utils: './utils',
+})
+```
+
+import betterModuleAlias from 'better-module-alias'
+betterModuleAlias(__dirname)
 ```
 
 #### Examples

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const someModule = require('$utils/someModule')
 import someModule from '$utils/someModule'
 ```
 
-An *alternative* way is to call the betterModuleAlias function, pass the aliases as the second argument.
+An *alternative* way is to call the betterModuleAlias function, and pass the aliases as the second argument.
 ```js
 require('better-module-alias')(__dirname, {
   $tests: './tests',

--- a/app.js
+++ b/app.js
@@ -5,13 +5,20 @@ require('./setupModuleAliases')(__dirname)
 // By only requiring $test1, we are sure the package is correctly updating the path.
 const assert = require('assert')
 const text1 = require('$test1')
-assert.equal(text1, 'It works - 1', "Directory aliasing isn't functioning correctly.")
+assert.equal(text1, 'It works - 1', "Directory aliasing is not working from the package.json")
 
 // This test is in ./tests/dirTest1
 // By only requiring $test2, we are sure the package is correctly updating the path.
 require('./setupModuleAliases')(__dirname, {"$test2": "./tests/dirTest2"})
 const text2 = require('$test2')
-assert.equal(text2, 'It works - 2', "Directory aliasing isn't functioning correctly.")
+assert.equal(text2, 'It works - 2', "Directory aliasing is not working from the alias object (second argument)")
+
+
+// This test is in ./tests/mid$test
+// This will ensure module aliases are not read in the MIDDLE of the path; only the beginning.
+require('./setupModuleAliases')(__dirname, {"$": "./this-should-not-be-found"})
+const text3 = require('./tests/mid$test')
+assert.equal(text3, 'It works - mid$test', "Directory aliasing is not working from the alias object (second argument)")
 
 console.info('All tests passing!')
 		

--- a/app.js
+++ b/app.js
@@ -1,16 +1,17 @@
-require('./setupModuleAliases')(__dirname,
-	// {"$dirTest": "./dirTest"}, // To test the secondary method, edit package.json and uncomment this
-	)
+require('./setupModuleAliases')(__dirname)
 
+
+// This test is in ./tests/dirTest1
+// By only requiring $test1, we are sure the package is correctly updating the path.
 const assert = require('assert')
-const text = require('$dirTest')
+const text1 = require('$test1')
+assert.equal(text1, 'It works - 1', "Directory aliasing isn't functioning correctly.")
 
-assert
-.equal(
-	text,
-	'It works!',
-	"Directory aliasing isn't functioning correctly.",
-)
+// This test is in ./tests/dirTest1
+// By only requiring $test2, we are sure the package is correctly updating the path.
+require('./setupModuleAliases')(__dirname, {"$test2": "./tests/dirTest2"})
+const text2 = require('$test2')
+assert.equal(text2, 'It works - 2', "Directory aliasing isn't functioning correctly.")
 
-console
-.info('All tests passing!')
+console.info('All tests passing!')
+		

--- a/app.js
+++ b/app.js
@@ -1,4 +1,6 @@
-require('./setupModuleAliases')(__dirname)
+require('./setupModuleAliases')(__dirname,
+	// {"$dirTest": "./dirTest"}, // To test the secondary method, edit package.json and uncomment this
+	)
 
 const assert = require('assert')
 const text = require('$dirTest')

--- a/dirTest/index.js
+++ b/dirTest/index.js
@@ -1,1 +1,0 @@
-module.exports = 'It works!'

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,8 @@
-declare function setupModuleAliases(root: string): void
+declare function setupModuleAliases(
+  root: string,
+  aliases: { [key: string]: string }
+): void;
 
-declare module 'better-module-alias' {
-  export = setupModuleAliases
+declare module "better-module-alias" {
+  export = setupModuleAliases;
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "yarn": ">=1.6.0"
   },
   "_moduleAliases": {
-    "$dirTest": "./dirTest"
+    "$test1": "./tests/dirTest1"
   },
   "publishConfig": {
     "access": "public"

--- a/setupModuleAliases.js
+++ b/setupModuleAliases.js
@@ -84,14 +84,8 @@ const originalResolveFilename = (
 
 Module
 ._resolveFilename = (
-	function(requestedFilePath, parentModule, isMain) {
-		const alias = (
-			moduleAliasNames
-			.find(alias => (
-				requestedFilePath
-				.includes(alias)
-			))
-		)
+	function(requestedFilePath, parentModule, isMain) { 
+		const alias = moduleAliasNames.find((aliasStart) => requestedFilePath.startsWith(aliasStart));
 
 		const modifiedFilePath = (
 			alias

--- a/setupModuleAliases.js
+++ b/setupModuleAliases.js
@@ -151,15 +151,9 @@ const addModuleAliases = (
 const getAliasesFromPackageJson = (basePath) => {
   const packageJsonPath = basePath.concat("/package.json");
   const packageJson = require(packageJsonPath);
-  if (!packageJson)
-    throw new Error(`No package.json could be located at the path: ${packageJsonPath}
-	This path is determined based on the require('better-module-alias')('PATH-GOES-HERE'). It is recommended you use require('better-module-alias')(__dirname)`);
 
   const moduleAliases = packageJson._moduleAliases;
-  if (!moduleAliases)
-    throw new Error(
-      'No module aliases could be found in the package.json. Please add a "_moduleAliases" property to the package.json.'
-    );
+  if (!moduleAliases) throw new Error('No module aliases could be found in the package.json. Please add a "_moduleAliases" property to the package.json.');
 
   return moduleAliases;
 };

--- a/setupModuleAliases.js
+++ b/setupModuleAliases.js
@@ -154,25 +154,30 @@ const addModuleAliases = (
 	}
 )
 
-const getAliasList = (
-	basePath => (
-		require(
-			basePath
-			.concat('/package.json')
-		)
-		._moduleAliases
-	)
-)
+const getAliasesFromPackageJson = (basePath) => {
+  const packageJsonPath = basePath.concat("/package.json");
+  const packageJson = require(packageJsonPath);
+  if (!packageJson)
+    throw new Error(`No package.json could be located at the path: ${packageJsonPath}
+	This path is determined based on the require('better-module-alias')('PATH-GOES-HERE'). It is recommended you use require('better-module-alias')(__dirname)`);
 
-const setupModuleAliases = (
-	basePath => {
-		addModuleAliases(
-			basePath,
-			getAliasList(
-				basePath
-			),
-		)
-	}
-)
+  const moduleAliases = packageJson._moduleAliases;
+  if (!moduleAliases)
+    throw new Error(
+      'No module aliases could be found in the package.json. Please add a "_moduleAliases" property to the package.json.'
+    );
 
-module.exports = setupModuleAliases
+  return moduleAliases;
+};
+
+const setupModuleAliases = (basePath, functionImports) => {
+  if (functionImports) {
+    var aliases = functionImports;
+  } else {
+    var aliases = getAliasesFromPackageJson(basePath);
+  }
+
+  addModuleAliases(basePath, aliases);
+};
+
+module.exports = setupModuleAliases;

--- a/setupModuleAliases.js
+++ b/setupModuleAliases.js
@@ -165,13 +165,14 @@ const getAliasesFromPackageJson = (basePath) => {
 };
 
 const setupModuleAliases = (basePath, functionImports) => {
-  if (functionImports) {
-    var aliases = functionImports;
-  } else {
-    var aliases = getAliasesFromPackageJson(basePath);
-  }
+	let aliases = []; 
+	if (functionImports) {
+		aliases = functionImports;
+	} else {
+		aliases = getAliasesFromPackageJson(basePath);
+	}
 
-  addModuleAliases(basePath, aliases);
+  	addModuleAliases(basePath, aliases);
 };
 
 module.exports = setupModuleAliases;

--- a/tests/dirTest1/index.js
+++ b/tests/dirTest1/index.js
@@ -1,0 +1,1 @@
+module.exports = 'It works - 1'

--- a/tests/dirTest2/index.js
+++ b/tests/dirTest2/index.js
@@ -1,0 +1,1 @@
+module.exports = 'It works - 2'

--- a/tests/mid$test/index.js
+++ b/tests/mid$test/index.js
@@ -1,0 +1,1 @@
+module.exports = 'It works - mid$test'


### PR DESCRIPTION
Hello! This is my first public PR, so if I've done anything wrong or missed anything, please let me know!

Instead of being forced to update the package.json, I've added an optional way to pass the __moduleAliases_ in, using the second argument of the default function.

Related to the change, I've also updated the types (index.d.ts), and the README (however, my addition is quite bad -- You'll probably want to reword/move the placement of it)

I also updated the "tests" to be better, and added my code as a test :)


Small note: If aliases are passed, then the package.json will _not_ be read. If you'd like both to be read, I can update it.

I also fixed #3 (and added a test for it) - if you'd like me to undo this, I can do so as well.
Edit: Forgot to mention, this obviously fixes #4 as well.